### PR TITLE
fix deprecation of createMuiTheme in @material-ui/core/styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ document.getElementsByTagName("body")[0].setAttribute('dir', 'rtl');
 2. Define a theme and set `direction` to `rtl`. Also defining an RTL theme might be not enough to flip all React Admin components. So we use [**jss-rtl**](https://github.com/alitaheri/jss-rtl) plugin to make sure everything works properly.
 
 ```javascript
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import {create} from 'jss';
 import rtl from 'jss-rtl';
 import {StylesProvider, jssPreset} from '@material-ui/core/styles';
@@ -72,7 +72,7 @@ import {StylesProvider, jssPreset} from '@material-ui/core/styles';
 // Configure JSS
 const jss = create({plugins: [...jssPreset().plugins, rtl()]});
 
-const theme = createMuiTheme({
+const theme = createTheme({
   direction: 'rtl',
 });
 


### PR DESCRIPTION
According to the deprecation of `createMuiTheme` in favor of `createTheme` in [https://github.com/mui-org/material-ui/pull/26004](https://github.com/mui-org/material-ui/pull/26004), I've updated the instruction in the readme.